### PR TITLE
Re-add include for UpdateClient.class.php

### DIFF
--- a/classic-code-snippets.php
+++ b/classic-code-snippets.php
@@ -227,7 +227,7 @@ function ccs_columns_id( $defaults ){
  */
 function ccs_custom_id_columns( $column_name, $post_id ){
 	if( $column_name === 'ccs_post_id' ){
-		echo '[css_snippets id=' . $post_id . ']';
+		echo '[ccs_snippets id=' . $post_id . ']';
 	}
 }
 

--- a/classic-code-snippets.php
+++ b/classic-code-snippets.php
@@ -16,6 +16,7 @@
 // Basic Security.
 defined( 'ABSPATH' ) or die;
 
+require_once('includes/UpdateClient.class.php');
 /**
  * Add display highlighter and line number styling to head section.
  *


### PR DESCRIPTION
Adds `require_once('includes/UpdateClient.class.php');` to `classic-code-snippets.php`.

This seems to have got lost when the main file was renamed in #11 